### PR TITLE
Minor fixes to tooltips

### DIFF
--- a/assets/js/tooltip.js
+++ b/assets/js/tooltip.js
@@ -324,7 +324,7 @@
 				off = off / scaleY;
 				tip.dataset.left=leftPos;
 				tip.dataset.top=topPos;
-				tip.setAttribute('style','position:absolute;left:'+(leftPos.toFixed(2))+'px;top:'+((topPos / scaleY).toFixed(2))+'px;display:'+(title ? 'block':'none')+';transform:translate3d(-50%,calc(-100% - '+off+'px),0);transition:all 0s;');
+				tip.setAttribute('style','position:absolute;left:'+(leftPos.toFixed(2))+'px;top:'+(topPos.toFixed(2))+'px;display:'+(title ? 'block':'none')+';transform:translate3d(-50%,calc(-100% - '+off+'px),0);transition:all 0s;');
 			}
 			box.style.background = fill;
 			box.style.transform = 'none';

--- a/assets/js/tooltip.js
+++ b/assets/js/tooltip.js
@@ -314,7 +314,18 @@
 			if(typ=="calendar-chart") off = (bb.height/2);
 			if(typ=="waffle-chart") off = (bb.height/2);
 
-			tip.setAttribute('style','position:absolute;left:'+(bb.left + bb.width/2 - bbo.left).toFixed(2)+'px;top:'+(bb.top + bb.height/2 - bbo.top).toFixed(2)+'px;display:'+(title ? 'block':'none')+';transform:translate3d(-50%,calc(-100% - '+off+'px),0);transition:all 0s;');
+			// Set tooltip position, with awareness of element scaling
+			// In scoped block to avoid pollution of top-level namespace with new variables.
+			{
+				const scaleX = holder.getBoundingClientRect().width / holder.offsetWidth;
+				const scaleY = holder.getBoundingClientRect().height / holder.offsetHeight;
+				const leftPos = (bb.left + bb.width/2 - bbo.left) / scaleX;
+				const topPos = (bb.top + bb.height/2 - bbo.top) / scaleY;
+				off = off / scaleY;
+				tip.dataset.left=leftPos;
+				tip.dataset.top=topPos;
+				tip.setAttribute('style','position:absolute;left:'+(leftPos.toFixed(2))+'px;top:'+((topPos / scaleY).toFixed(2))+'px;display:'+(title ? 'block':'none')+';transform:translate3d(-50%,calc(-100% - '+off+'px),0);transition:all 0s;');
+			}
 			box.style.background = fill;
 			box.style.transform = 'none';
 			arr.style['border-top-color'] = fill;

--- a/assets/js/tooltip.js
+++ b/assets/js/tooltip.js
@@ -265,7 +265,8 @@
 			}
 			pt.setAttribute('aria-label',tt.replace(/<br[\\\s]*>/g,'; ').replace(/<[^\>]+>/g,' '));
 
-			wide = document.body.getBoundingClientRect().width;
+			// Fix for situations where body is not full window width or has margins, this breaks tooltips.
+			wide = document.body.getBoundingClientRect().right;
 
 			// Set the position of the holder element
 			holder.style.position = 'relative';


### PR DESCRIPTION
These changes deal with situations where the svg is scaled for some reason (as happened when using a hex map inside a reveal presentation), and where the body is not as wide as the window.

The changes should be relatively minor, and are working for Bradford 2025. I'd like to include them in a patch release.